### PR TITLE
Relax rails version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ombu_labs-hubspot (0.1.0)
       hubspot-api-client (= 11.1.1)
-      rails (~> 6.0)
+      rails (>= 6.0)
       sidekiq (>= 5.0)
 
 GEM

--- a/lib/ombu_labs/hubspot/version.rb
+++ b/lib/ombu_labs/hubspot/version.rb
@@ -1,5 +1,5 @@
 module OmbuLabs
   module Hubspot
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/ombu_labs-hubspot.gemspec
+++ b/ombu_labs-hubspot.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", "~> 6.0"
+  spec.add_dependency "rails", ">= 6.0"
   spec.add_dependency "hubspot-api-client", "11.1.1"
   spec.add_dependency "sidekiq", ">= 5.0"
 end


### PR DESCRIPTION
Hey @rishijain 

I needed to relax the Rails version on these gems now that the marketing team updated the Rails version in Fastruby.io, and they will soon in OmbuLabs. 
